### PR TITLE
Fix virtual keyboard does not appear issue.

### DIFF
--- a/src/QCefView/CefViewBrowserApp/QCefViewBrowserApp.cpp
+++ b/src/QCefView/CefViewBrowserApp/QCefViewBrowserApp.cpp
@@ -33,6 +33,7 @@ QCefViewBrowserApp::OnBeforeCommandLineProcessing(const CefString& process_type,
   command_line->AppendSwitch("disable-direct-composition");
   command_line->AppendSwitchWithValue("disable-features", "NetworkService");
   command_line->AppendSwitchWithValue("renderer-process-limit", "1");
+  command_line->AppendSwitchWithValue("disable-usb-keyboard-detect", "1");
 }
 
 void

--- a/src/QCefView/CefViewBrowserApp/QCefViewBrowserHandler.cpp
+++ b/src/QCefView/CefViewBrowserApp/QCefViewBrowserHandler.cpp
@@ -176,6 +176,17 @@ QCefViewBrowserHandler::OnSetFocus(CefRefPtr<CefBrowser> browser, FocusSource so
   return false;
 }
 
+void
+QCefViewBrowserHandler::OnGotFocus(CefRefPtr<CefBrowser> browser)
+{
+  CEF_REQUIRE_UI_THREAD();
+
+  auto host = main_browser_->GetHost();
+  if (host != nullptr) {
+    host->SetFocus(true);
+  }
+}
+
 bool
 QCefViewBrowserHandler::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
                                       const CefKeyEvent& event,

--- a/src/QCefView/CefViewBrowserApp/QCefViewBrowserHandler.h
+++ b/src/QCefView/CefViewBrowserApp/QCefViewBrowserHandler.h
@@ -80,6 +80,7 @@ public:
   {
     return pKeyboardHandler_ ? pKeyboardHandler_ : this;
   }
+  virtual CefRefPtr<CefFocusHandler> GetFocusHandler() override { return this; }
   virtual CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
   virtual CefRefPtr<CefLoadHandler> GetLoadHandler() override { return this; }
   virtual CefRefPtr<CefRequestHandler> GetRequestHandler() override { return this; }
@@ -157,6 +158,8 @@ public:
   virtual void OnTakeFocus(CefRefPtr<CefBrowser> browser, bool next) override;
 
   virtual bool OnSetFocus(CefRefPtr<CefBrowser> browser, FocusSource source) override;
+
+  virtual void OnGotFocus(CefRefPtr<CefBrowser> browser) override;
 
 #pragma endregion CefFocusHandler
 


### PR DESCRIPTION
Virtual keyboard dost not appear when user touch the text area through a touch screen, another issue is, browser does not request focus, so keyboard inputting is also disabled before user click via mouse.