### PR TITLE
Minor fixes to compile and run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/build.*
+/build/*
 /dep/*
 *.aps
 .vs

--- a/config.cmake
+++ b/config.cmake
@@ -15,7 +15,7 @@ set(QT_SDK_DIR
 #
 set(CEF_SDK_DIR
   # Change this value to the CEF binary distribution path of your build environment
-  "${CMAKE_CURRENT_SOURCE_DIR}/dep/cef_binary_75.1.14+gc81164e+chromium-75.0.3770.100_windows32"
+  "${CMAKE_CURRENT_SOURCE_DIR}/dep/cef_binary_76.1.13+gf19c584+chromium-76.0.3809.132_windows64"
 )
 
 #################################################################################

--- a/src/QCefView/CCefSetting.cpp
+++ b/src/QCefView/CCefSetting.cpp
@@ -41,7 +41,7 @@ CCefSetting::initializeInstance()
 
 CCefSetting::CCefSetting()
 {
-  QDir ExeDir = QDir::current();
+  QDir ExeDir = qApp->applicationDirPath();
 
   QString strExePath = ExeDir.filePath(RENDER_PROCESS_NAME);
   browser_sub_process_path.FromString(QDir::toNativeSeparators(strExePath).toStdString());

--- a/test/QCefViewTest/customcefview.cpp
+++ b/test/QCefViewTest/customcefview.cpp
@@ -8,24 +8,6 @@
 
 #include "customcefview.h"
 
-
-namespace {
-  void dispatchToMainThread(std::function<void()> callback)
-  {
-      // any thread
-      QTimer* timer = new QTimer();
-      timer->moveToThread(qApp->thread());
-      timer->setSingleShot(true);
-      QObject::connect(timer, &QTimer::timeout, [=]()
-      {
-          // main thread
-          callback();
-          timer->deleteLater();
-      });
-      QMetaObject::invokeMethod(timer, "start", Qt::QueuedConnection, Q_ARG(int, 0));
-  }
-}
-
 CustomCefView::~CustomCefView() {}
 
 void
@@ -50,9 +32,9 @@ CustomCefView::onQCefUrlRequest(const QString& url)
                          "Url: %1")
                    .arg(url);
 
-  dispatchToMainThread([=]() {
+  QMetaObject::invokeMethod(this, [=]() {
       QMessageBox::information(this->window(), title, text);
-  });
+  }, Qt::QueuedConnection);
 }
 
 void
@@ -63,9 +45,9 @@ CustomCefView::onQCefQueryRequest(const QCefQuery& query)
                          "Query: %1")
                    .arg(query.reqeust());
 
-  dispatchToMainThread([=]() {
+  QMetaObject::invokeMethod(this, [=]() {
     QMessageBox::information(this->window(), title, text);
-  });
+  }, Qt::QueuedConnection);
 
   QString response = query.reqeust().toUpper();
   query.setResponseResult(true, response);
@@ -96,7 +78,7 @@ CustomCefView::onInvokeMethodNotify(int browserId, int frameId, const QString& m
                          "Arguments: ...")
                    .arg(method);
 
-  dispatchToMainThread([=]() {
+  QMetaObject::invokeMethod(this, [=]() {
     QMessageBox::information(this->window(), title, text);
-  });
+  }, Qt::QueuedConnection);
 }

--- a/test/QCefViewTest/customcefview.cpp
+++ b/test/QCefViewTest/customcefview.cpp
@@ -2,9 +2,6 @@
 #include <QMessageBox>
 #include <QColor>
 #include <QRandomGenerator>
-#include <functional>
-#include <qtimer>
-#include <QCoreApplication>
 
 #include "customcefview.h"
 


### PR DESCRIPTION
I'm using MSVC2019, compiling to x64. More details below. Thanks for this repo @tishion! 

- Getting correct runtime exe path via qApp.
- Message popup widget must be created on Qt main thread.
- Switching to the CEF build specified in main readme.
- Ignoring /build dir (cosmetic).

Built and run successfully with:

Qt 5.15.2 (msvc2019_64) SDK
cef_binary_76.1.13+gf19c584+chromium-76.0.3809.132_windows64

Must set these env vars, e.g.:

`QTDIR=c:/Qt/5.15.2/msvc2019_64`
`QT_QPA_PLATFORM_PLUGIN_PATH=c:/Qt/5.15.2/msvc2019_64/plugins`
